### PR TITLE
Improved playback

### DIFF
--- a/play.py
+++ b/play.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from time import sleep
 import ntpath
+import pyautogui
 from pyautogui import press
 
 DEFAULT_TEMPO = 0.5
@@ -117,7 +118,8 @@ def note2freq(x):
 
 
 if __name__ == '__main__':
-
+    
+    pyautogui.PAUSE = 0
     # Import the MIDI file...
     mid = MidiFile(sys.argv[1])
     if mid.type == 3:
@@ -127,7 +129,7 @@ if __name__ == '__main__':
     """
         wait 2 seconds to switch window
     """
-    #sleep(2)
+    sleep(2)
     try:
         for msg in mid.play():
             if hasattr(msg, 'velocity'):

--- a/play.py
+++ b/play.py
@@ -119,7 +119,7 @@ def note2freq(x):
 
 if __name__ == '__main__':
     
-    pyautogui.PAUSE = 0
+    pyautogui.PAUSE = 0.05
     # Import the MIDI file...
     mid = MidiFile(sys.argv[1])
     if mid.type == 3:


### PR DESCRIPTION
Adjusts the pyautogui default delay between actions to improve midi files playback.
Set it to 0.05 but value could be adjusted depending on the frame rate.
0.05 seems however to be a sweet spot for the mid files I tried